### PR TITLE
Various optimizations

### DIFF
--- a/polyfinder/Makefile
+++ b/polyfinder/Makefile
@@ -1,7 +1,6 @@
 CXXFLAGS=-O3 -Wall -Wextra -pedantic -pthread -lboost_system -std=gnu++17 -march=native -mtune=native
-
-#g++ square.cpp -O3 -Wall -pthread -lboost_system -std=c++17 -o square_mt
-
+#Use this only when profiling the code
+#CXXPROFFLAGS=-ggdb -pg
 
 .PHONY: all clean masks.hpp
 
@@ -14,7 +13,7 @@ masks: masks.cpp config.h utils.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $<
 
 square_mt: square.cpp masks.hpp gf2_monomial.cpp stringops.cpp parallel_hashmap/phmap.h config.h utils.cpp
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $<
+	$(CXX) $(CXXPROFFLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $@ $<
 
 clean:
 	@rm -rf square_mt masks masks.hpp

--- a/polyfinder/config.h
+++ b/polyfinder/config.h
@@ -1,5 +1,8 @@
 #pragma once
 
+//Set this to disable asserts
+#define NDEBUG
+
 //This no longer needs to be prime :D
 //TODO use this to distribute the thread local searches (and reduce the cmap size)
 #define THREADS 8

--- a/polyfinder/config.h
+++ b/polyfinder/config.h
@@ -38,8 +38,10 @@ static constexpr uint64_t imasklen = (polynomial_degree+1)-masklen;
 static constexpr uint64_t masklenb = (masklen-log_mdrop+7)/8;
 static constexpr uint64_t imasklenb = (imasklen+7)/8;
 static constexpr uint128_t pmask = polynomial_degree == 127? ((uint128_t)-1) : (((uint128_t)1) << (polynomial_degree+1))-((uint128_t)1);
-static constexpr uint64_t total_map_size = (uint64_t)(((uint64_t)1 << (polynomial_degree/3 + BETA)) * ALPHA);
-// static constexpr uint64_t total_map_size = (uint64_t)1<<25;
-static constexpr uint64_t exp_len = (get_degree(total_map_size) + 8) / 8;
+static constexpr uint64_t total_map_size = optimize_map_size((uint64_t)(((uint64_t)1 << (polynomial_degree/3 + BETA)) * ALPHA));
+//Items go from 1 to total_map_size-1 the 0 would mean we have to take away one but we already did so with the optimization
+static constexpr uint64_t exp_bit_len = get_degree(total_map_size-1) + 1;
+static constexpr uint64_t exp_len = (get_degree(total_map_size-1) + 8) / 8;
 static constexpr uint64_t coll_set_size = total_map_size/(THREADS*THREADS*BUCKETS);
 static constexpr uint64_t base_coll_set_size = total_map_size/(THREADS*BUCKETS);
+static constexpr uint64_t stage1_table_len = (1 << masklen) / THREADS;

--- a/polyfinder/config.h
+++ b/polyfinder/config.h
@@ -3,7 +3,6 @@
 //This no longer needs to be prime :D
 //TODO use this to distribute the thread local searches (and reduce the cmap size)
 #define THREADS 8
-#define BUCKETS (65536/THREADS)
 #define COLL_BUCKETS (65536/THREADS)
 #define BETA    1
 #define ALPHA   1
@@ -32,7 +31,7 @@
 #include "utils.cpp"
 
 static constexpr uint32_t polynomial_degree = get_degree(POLY);
-static constexpr uint32_t log_mdrop = get_degree(BUCKETS*THREADS);
+static constexpr uint32_t log_mdrop = get_degree(THREADS);
 static constexpr uint64_t masklen = polynomial_degree/3-2;
 static constexpr uint64_t imasklen = (polynomial_degree+1)-masklen;
 static constexpr uint64_t masklenb = (masklen-log_mdrop+7)/8;
@@ -42,6 +41,5 @@ static constexpr uint64_t total_map_size = optimize_map_size((uint64_t)(((uint64
 //Items go from 1 to total_map_size-1 the 0 would mean we have to take away one but we already did so with the optimization
 static constexpr uint64_t exp_bit_len = get_degree(total_map_size-1) + 1;
 static constexpr uint64_t exp_len = (get_degree(total_map_size-1) + 8) / 8;
-static constexpr uint64_t coll_set_size = total_map_size/(THREADS*THREADS*BUCKETS);
-static constexpr uint64_t base_coll_set_size = total_map_size/(THREADS*BUCKETS);
-static constexpr uint64_t stage1_table_len = (1 << masklen) / THREADS;
+static constexpr uint64_t coll_set_size = total_map_size/(THREADS*THREADS*COLL_BUCKETS);
+static constexpr uint64_t stage1_table_len = ((uint64_t)1 << masklen) / THREADS;

--- a/polyfinder/config.h
+++ b/polyfinder/config.h
@@ -9,6 +9,12 @@
 #define ALPHA   1
 //#define SEED    (time(NULL)+1)
 #define SEED    (1618440951)
+// You may want to set these to 1 when 2^x exponentiation is fast
+
+// Drop the inverse mask from the data stored in the hash
+// this gains imasklenb bytes per entry (up to max(2^masklen,total_map_size))
+// at the expense of one 2^x exponentiation per generated binomial
+#define CMAP_DROP_IMASK 1
 
 //#define DEBUG_MESSAGES 1
 #define IN_MEM_GENERATION 1

--- a/polyfinder/config.h
+++ b/polyfinder/config.h
@@ -3,7 +3,12 @@
 //This no longer needs to be prime :D
 //TODO use this to distribute the thread local searches (and reduce the cmap size)
 #define THREADS 8
-#define COLL_BUCKETS (65536/THREADS)
+//This allows you to use a time memory trade off, by keeping the stage 1 hash tables
+//smaller. In exchange, you have to perform more searches to fill the tables.
+#define STAGE1_TASKS THREADS
+//This instead uses a different trick, by keeping storage memory more sparse we can reduce
+//The number of elements on each list
+#define COLL_BUCKETS ((1<<16))
 #define BETA    1
 #define ALPHA   1
 //#define SEED    (time(NULL)+1)
@@ -31,15 +36,13 @@
 #include "utils.cpp"
 
 static constexpr uint32_t polynomial_degree = get_degree(POLY);
-static constexpr uint32_t log_mdrop = get_degree(THREADS);
 static constexpr uint64_t masklen = polynomial_degree/3-2;
 static constexpr uint64_t imasklen = (polynomial_degree+1)-masklen;
-static constexpr uint64_t masklenb = (masklen-log_mdrop+7)/8;
 static constexpr uint64_t imasklenb = (imasklen+7)/8;
 static constexpr uint128_t pmask = polynomial_degree == 127? ((uint128_t)-1) : (((uint128_t)1) << (polynomial_degree+1))-((uint128_t)1);
 static constexpr uint64_t total_map_size = optimize_map_size((uint64_t)(((uint64_t)1 << (polynomial_degree/3 + BETA)) * ALPHA));
 //Items go from 1 to total_map_size-1 the 0 would mean we have to take away one but we already did so with the optimization
 static constexpr uint64_t exp_bit_len = get_degree(total_map_size-1) + 1;
 static constexpr uint64_t exp_len = (get_degree(total_map_size-1) + 8) / 8;
-static constexpr uint64_t coll_set_size = total_map_size/(THREADS*THREADS*COLL_BUCKETS);
-static constexpr uint64_t stage1_table_len = ((uint64_t)1 << masklen) / THREADS;
+static constexpr uint64_t coll_set_size = total_map_size/(COLL_BUCKETS*THREADS);
+static constexpr uint64_t stage1_table_len = ((uint64_t)1 << masklen) / STAGE1_TASKS;

--- a/polyfinder/gf2_monomial.cpp
+++ b/polyfinder/gf2_monomial.cpp
@@ -2,6 +2,8 @@
 // amazing work. Thanks man! You gave me the bits I was missing to make this go faster than GME
 // https://github.com/QMechanic/GF2_128_lib/blob/master/gf2x_arithmetic.cpp
 
+#include <utility>
+
 // px*2
 __attribute__((always_inline)) PUREFUN static constexpr inline uint128_t next_monomial(uint128_t px)
 {
@@ -70,11 +72,18 @@ PUREFUN static constexpr inline uint128_t gf2x_divide(uint256_t a, uint128_t b)
 #include <smmintrin.h>
 #include <tmmintrin.h>
 #include <wmmintrin.h>
+#include <avxintrin.h>
+#include <avx2intrin.h>
 
 typedef struct gfmm256 {
     __m128i lo;
     __m128i hi;
 } gfmm256;
+
+typedef struct gfmm512 {
+    __m256i lo;
+    __m256i hi;
+} gfmm512;
 
 PUREFUN static constexpr inline __m128i tovector(uint128_t a)
 {
@@ -95,6 +104,71 @@ PUREFUN  static constexpr inline uint128_t fromvector(__m128i a)
     return (((uint128_t)hi)<<64)|((uint128_t)lo);
 }
 
+PUREFUN static constexpr inline __m256i todvector(uint128_t a)
+{
+    uint64_t hi = a >> 64, lo = a;
+    return __extension__ (__m256i)(__v4du){ lo, hi, lo, hi };
+}
+
+PUREFUN static constexpr inline __m256i todvector(uint128_t a, uint128_t b)
+{
+    uint64_t hi1 = a >> 64, lo1 = a;
+    uint64_t hi2 = b >> 64, lo2 = b;
+    return __extension__ (__m256i)(__v4du){ lo1, hi1, lo2, hi2 };
+}
+
+PUREFUN static constexpr inline __m256i todvector64(uint64_t a)
+{
+    //Use little endian so shifts are efficient
+    return __extension__ (__m256i)(__v4du){ a, 0, a, 0 };
+}
+
+PUREFUN static constexpr inline __m256i todvector64(uint64_t a, uint64_t b)
+{
+    //Use little endian so shifts are efficient
+    return __extension__ (__m256i)(__v4du){ a, 0, b, 0 };
+}
+
+
+PUREFUN  static constexpr inline uint128_t fromdvector(__m256i a, const int pos)
+{
+    uint64_t hi = __extension__ ((__v4du) a)[pos*2+1], lo = __extension__ ((__v4du) a)[pos*2+0];
+    return (((uint128_t)hi)<<64)|((uint128_t)lo);
+}
+
+PUREFUN  static constexpr inline __m128i m128i0fromdvector(__m256i a)
+{
+    return (__m128i) __builtin_ia32_si_si256((__v8si)a);
+}
+
+PUREFUN  static constexpr inline __m128i m128i1fromdvector(__m256i a)
+{
+    return (__m128i) __builtin_ia32_extract128i256 ((__v4di)a, 1);
+}
+
+PUREFUN  static constexpr inline __m128i m128ifromdvector(__m256i a, const int pos)
+{
+    return (__m128i) __builtin_ia32_extract128i256 ((__v4di)a, pos);
+}
+
+
+PUREFUN static inline __m256i todvector(__m128i a, __m128i b)
+{
+    return (__m256i) __builtin_ia32_vinsertf128_si256((__v8si)__builtin_ia32_si256_si ((__v4si)a), (__v4si)b, 1);
+}
+
+PUREFUN static inline __m256i todvector(__m128i a)
+{
+    return (__m256i) __builtin_ia32_vinsertf128_si256((__v8si)__builtin_ia32_si256_si ((__v4si)a), (__v4si)a, 1);
+}
+
+
+PUREFUN static inline __m256i _clmulepi64_si256(__m256i a, __m256i b, const int w)
+{
+    return todvector(_mm_clmulepi64_si128(m128i0fromdvector(a),m128i0fromdvector(b),w),_mm_clmulepi64_si128(m128i1fromdvector(a),m128i1fromdvector(b),w));
+}
+
+
 // karatsuba algorithm
 // a*b, 128bit input, 256 bit output
 PUREFUN  static inline gfmm256 gf2x_mul(__m128i a, __m128i b)
@@ -112,6 +186,22 @@ PUREFUN  static inline gfmm256 gf2x_mul(__m128i a, __m128i b)
     return out;
 }
 
+PUREFUN  static inline gfmm512 gf2x_mul_2(__m256i a, __m256i b)
+{
+    gfmm512 out = {};
+    __m256i z0 = _clmulepi64_si256(a, b, 0x00);
+    __m256i z2 = _clmulepi64_si256(a, b, 0x11);
+    __m256i t1 = _mm256_xor_si256(_mm256_unpackhi_epi64(a,b),_mm256_unpacklo_epi64(a,b));
+    __m256i z1 = _mm256_xor_si256(_clmulepi64_si256(t1, t1, 0x10),_mm256_xor_si256(z0, z2));
+    //Order of unpack is first low bits then high bits
+    // Return: z0lo, z0hi ^ z1lo, z1hi ^ z2lo, z2hi
+    __m256i t2 = _mm256_xor_si256(_mm256_unpackhi_epi64(z0,z1),_mm256_unpacklo_epi64(z1,z2));
+    out.lo = _mm256_unpacklo_epi64(z0,t2);
+    out.hi = _mm256_unpackhi_epi64(t2,z2);
+    return out;
+}
+
+
 // Same but dropping the higher 64-bits use schoolbook instead
 // TODO: maybe there is a smart trick to get this with only two multiplications
 PUREFUN  static inline __m128i gf2x_mullo(__m128i a, __m128i b)
@@ -119,12 +209,26 @@ PUREFUN  static inline __m128i gf2x_mullo(__m128i a, __m128i b)
     return _mm_xor_si128(_mm_bslli_si128(_mm_xor_si128(_mm_clmulepi64_si128(a, b, 0x01),_mm_clmulepi64_si128(a, b, 0x10)),8),_mm_clmulepi64_si128(a, b, 0x00));
 }
 
+PUREFUN  static inline __m256i gf2x_mullo_2(__m256i a, __m256i b)
+{
+    return _mm256_xor_si256(_mm256_bslli_epi128(_mm256_xor_si256(_clmulepi64_si256(a, b, 0x01),_clmulepi64_si256(a, b, 0x10)),8),_clmulepi64_si256(a, b, 0x00));
+}
+
+
 // a², 128 bit input, 256 bit output
 PUREFUN static inline gfmm256 gf2x_square(__m128i a)
 {
     gfmm256 out = {};
     out.lo = _mm_clmulepi64_si128(a, a, 0x00);
     out.hi = _mm_clmulepi64_si128(a, a, 0x11);
+    return out;
+}
+
+PUREFUN static inline gfmm512 gf2x_square_2(__m256i a)
+{
+    gfmm512 out = {};
+    out.lo = _clmulepi64_si256(a, a, 0x00);
+    out.hi = _clmulepi64_si256(a, a, 0x11);
     return out;
 }
 
@@ -158,8 +262,41 @@ PUREFUN static inline __m128i pdgshr(gfmm256 in) {
 }
 
 
-static constexpr __m128i mpoly_inv = tovector(gf2x_divide(shl(u256c(1), 2*polynomial_degree), POLY));
-static constexpr __m128i mpoly = tovector(POLY);
+PUREFUN static inline __m256i pdgshr_2(gfmm512 in) {
+    constexpr uint32_t div = (polynomial_degree / 64) * 8;
+    constexpr uint32_t div2 = polynomial_degree / 8;
+    constexpr uint32_t rem = polynomial_degree % 64;
+    constexpr uint32_t rem2 = 64-rem;
+    if constexpr (polynomial_degree >= 256) {
+        return _mm256_setzero_si256();
+    } else if constexpr (polynomial_degree == 128) {
+        return in.hi;
+    } else if constexpr (polynomial_degree % 8 == 0) {
+        //Combine hi and lo bytewise
+        if constexpr (polynomial_degree > 128)
+            return _mm256_bsrli_epi128(in.hi,div2);
+        else
+            return _mm256_alignr_epi8(in.hi,in.lo,div2);
+    } else {
+        //Combine hi and lo bitwise slow!
+        if constexpr (polynomial_degree > 192)
+            return _mm256_srli_epi64(_mm256_bsrli_epi128(in.hi, 8),rem);
+        else if constexpr (polynomial_degree > 128)
+            return _mm256_or_si256(_mm256_srli_epi64(in.hi,rem),_mm256_slli_epi64(_mm256_bsrli_epi128(in.hi,8),rem2));
+        else if constexpr (polynomial_degree > 64)
+            return _mm256_or_si256(_mm256_srli_epi64(_mm256_alignr_epi8(in.hi,in.lo,div),rem),_mm256_slli_epi64(in.hi,rem2));
+        else
+            return _mm256_or_si256(_mm256_srli_epi64(in.lo,rem),_mm256_slli_epi64(_mm256_alignr_epi8(in.hi,in.lo,div+8),rem2));
+    }
+}
+
+
+static constexpr uint128_t umpoly_inv = gf2x_divide(shl(u256c(1), 2*polynomial_degree), POLY);
+static constexpr uint128_t umpoly = POLY;
+static constexpr __m128i mpoly_inv = tovector(umpoly_inv);
+static constexpr __m128i mpoly = tovector(umpoly);
+static constexpr __m256i mpoly_inv_2 = todvector(umpoly_inv);
+static constexpr __m256i mpoly_2 = todvector(umpoly);
 // This calculates in(x) mod P(x) with just multiplications and additions
 // P(x) is assumed to be constant and that's why this can optimize it
 // TODO: This maybe can be made faster if we make multiplications which are shift-aware
@@ -167,6 +304,12 @@ PUREFUN static inline __m128i gf2x_reduce(gfmm256 in)
 {
     return _mm_xor_si128(in.lo,gf2x_mullo(pdgshr(gf2x_mul(pdgshr(in), mpoly_inv)), mpoly));
 }
+
+PUREFUN static inline __m256i gf2x_reduce_2(gfmm512 in)
+{
+    return _mm256_xor_si256(in.lo,gf2x_mullo_2(pdgshr_2(gf2x_mul_2(pdgshr_2(in), mpoly_inv_2)), mpoly_2));
+}
+
 
 PUREFUN static inline uint128_t gf2x_multiply_fast(uint128_t a, uint128_t b)
 {
@@ -181,32 +324,78 @@ PUREFUN static inline uint128_t gf2x_square_fast(uint128_t a)
 
 template<int size>
 struct exp2vals{
-  __m128i arr[size];
+  uint128_t arru[size] = {};
+  __m128i arr[size] = {};
   constexpr exp2vals():arr(){
-    uint128_t last = 2;
-    if (size > 0) arr[0] = tovector(last);
-    for(int i = 1; i < size; i++) {
-        last = gf2x_multiply(last, last);
-        arr[i] = tovector(last);
+    if (size > 0) arru[0] = 1;
+    if (size > 1) arru[1] = 2;
+    for(int i = 2; i < size; i++) {
+        arru[i] = gf2x_multiply(arru[i-1], arru[i-1]);
+    }
+    for(int i = 0; i < size; i++) {
+        arr[i] = tovector(arru[i]);
     }
   }
 };
 
-static constexpr exp2vals arre2 = exp2vals<64>();
+static constexpr exp2vals arre2 = exp2vals<65>();
+
+PUREFUN static inline __m128i gf_exp2_m128(uint64_t n)
+{
+    int i = __builtin_ffsll(n);
+    __m128i y = arre2.arr[i];
+    n = unlikely(__builtin_popcountll(n)<=1)? 0 : n >> i;
+    #pragma GCC unroll 63
+    while (unlikely(n != 0))
+    {
+        int s=__builtin_ffsll(n);
+        i+=s;
+        y = gf2x_reduce(gf2x_mul(y,arre2.arr[i]));
+        n>>=s;
+    }
+    return y;
+}
+
 
 PUREFUN static inline uint128_t gf_exp2(uint64_t n)
 {
-    __m128i y = tovector64(1);
-    #pragma GCC unroll 64
-    for (uint32_t i = 0; i < 64; ++i)
+    return fromvector(gf_exp2_m128(n));
+}
+
+PUREFUN static inline __m256i gf_exp2_m256(uint64_t n1, uint64_t n2)
+{
+    int i1 = __builtin_ffsll(n1), i2 = __builtin_ffsll(n2);
+    __m256i y = todvector(arre2.arr[i1],arre2.arr[i2]);
+    n1 = unlikely(__builtin_popcountll(n1)<=1)? 0 : n1 >> i1;
+    n2 = unlikely(__builtin_popcountll(n2)<=1)? 0 : n2 >> i2;
+    #pragma GCC unroll 63
+    while (unlikely(n1 != 0 || n2 != 0))
     {
-        if (unlikely(n==0))
-            return fromvector(y);
-        else if (unlikely(n % 2 == 1))
-            y = gf2x_reduce(gf2x_mul(y,arre2.arr[i]));
-        n>>=1;
+        int s1=__builtin_ffsll(n1), s2=__builtin_ffsll(n2);
+        i1+=s1; i2+=s2;
+        if (likely(n1 != 0))
+            if(likely(n2 != 0))
+                y = gf2x_reduce_2(gf2x_mul_2(y,todvector(arre2.arru[i1],arre2.arru[i2])));
+            else //n2==0
+            y = _mm256_inserti128_si256(y,gf2x_reduce(gf2x_mul(m128i0fromdvector(y),arre2.arr[i1])),0);
+        else //n1==0
+            y = _mm256_inserti128_si256(y,gf2x_reduce(gf2x_mul(m128i1fromdvector(y),arre2.arr[i2])),1);
+        n1>>=s1; n2>>=s2;
     }
-    return fromvector(y);
+    return y;
+}
+
+
+PUREFUN static inline std::pair<uint128_t,uint128_t> gf_exp2_2(uint64_t n1, uint64_t n2)
+{
+    __m256i y = gf_exp2_m256(n1,n2);
+    return std::pair(fromdvector(y,0),fromdvector(y,1));
+}
+
+PUREFUN static inline uint128_t gf_exp2_xor_2(uint64_t n1, uint64_t n2)
+{
+    __m256i y = gf_exp2_m256(n1,n2);
+    return fromvector(_mm_xor_si128(m128i0fromdvector(y),m128i1fromdvector(y)));
 }
 
 
@@ -276,4 +465,16 @@ __attribute__ ((noinline)) static uint128_t gf_exp2(uint64_t n)
     }
     return y;
 }
+
+PUREFUN static inline std::pair<uint128_t,uint128_t> gf_exp2_2(uint64_t n1, uint64_t n2)
+{
+    return std::pair(gf_exp2(n1),gf_exp2(n2));
+}
+
+PUREFUN static inline uint128_t gf_exp2_xor_2(uint64_t n1, uint64_t n2)
+{
+    return gf_exp2(n1)^gf_exp2(n2);
+}
+
+
 #endif

--- a/polyfinder/masks.cpp
+++ b/polyfinder/masks.cpp
@@ -55,7 +55,7 @@ int main()
     gen_mask_bits(mask, maskbits,polynomial_degree,1);
     gen_mask_bits(mask, imaskbits,polynomial_degree,0);
     cout << "#pragma once" << endl;
-    cout << "static constexpr uint128_t mask = (((uint128_t)"<< ((uint64_t)(mask >> 64)) << ") << 64)|((uint128_t)" << ((uint64_t)mask) << ");"<< endl;
+    cout << "static constexpr uint128_t mask = (((uint128_t)"<< ((uint64_t)(mask >> 64)) << "U) << 64)|((uint128_t)" << ((uint64_t)mask) << "U);"<< endl;
     cout << "static constexpr uint64_t maskseed = "<< maskseed << ";"<< endl;
     gen_mask_fun("get_mask_bits",masklen,maskbits);
     gen_mask_fun("get_imask_bits",imasklen,imaskbits);

--- a/polyfinder/square.cpp
+++ b/polyfinder/square.cpp
@@ -78,7 +78,7 @@ PUREFUN constexpr inline uint64_t unpack_exp(const exp_t &exp) {
     return rv;
 }
 
-PUREFUN constexpr inline mask_t pack_mask(uint128_t mask) {
+PUREFUN constexpr inline mask_t pack_mask(mask_int_t mask) {
     mask_t rv = {};
     for (uint i = 0; i < masklenb; i++)
         rv.mask[i] = mask >> (8*i);
@@ -88,14 +88,14 @@ PUREFUN constexpr inline mask_t pack_mask(uint128_t mask) {
 }
 
 
-PUREFUN constexpr inline uint128_t unpack_mask(const mask_t &mask) {
-    uint128_t rv = 0;
+PUREFUN constexpr inline mask_int_t unpack_mask(const mask_t &mask) {
+    mask_int_t rv = 0;
     for (uint i = 0; i < masklenb; i++)
-        rv |= ((uint128_t)mask.mask[i]) <<  (8*i);
+        rv |= ((mask_int_t)mask.mask[i]) <<  (8*i);
     return rv;
 }
 
-PUREFUN constexpr inline imask_t pack_imask(uint128_t imask) {
+PUREFUN constexpr inline imask_t pack_imask(imask_int_t imask) {
    imask_t rv = {};
     for (uint i = 0; i < imasklenb; i++)
         rv.imask[i] = imask >> (8*i);
@@ -103,10 +103,10 @@ PUREFUN constexpr inline imask_t pack_imask(uint128_t imask) {
 }
 
 
-PUREFUN constexpr inline uint128_t unpack_imask(const imask_t &imask) {
-    uint128_t rv = 0;
+PUREFUN constexpr inline imask_int_t unpack_imask(const imask_t &imask) {
+    imask_int_t rv = 0;
     for (uint i = 0; i < imasklenb; i++)
-        rv |= ((uint128_t)imask.imask[i]) <<  (8*i);
+        rv |= ((imask_int_t)imask.imask[i]) <<  (8*i);
     return rv;
 }
 
@@ -156,7 +156,7 @@ namespace std {
         typedef size_t result_type;
         PUREFUN inline result_type operator () (const argument_type& x) const
         {
-            uint128_t t = get_imask_bits(gf_exp2(unpack_exp(x.e1))^gf_exp2(unpack_exp(x.e2)));
+            imask_int_t t = get_imask_bits(gf_exp2(unpack_exp(x.e1))^gf_exp2(unpack_exp(x.e2)));
             if constexpr (sizeof(result_type) >= imasklen) {
                 return t;
             } else {
@@ -175,7 +175,7 @@ namespace std {
         typedef size_t result_type;
         PUREFUN inline result_type operator () (const argument_type& x) const
         {
-            uint64_t t = get_mask_bits(gf_exp2(unpack_exp(x.exponent)));
+            mask_int_t t = get_mask_bits(gf_exp2(unpack_exp(x.exponent)));
             if constexpr (sizeof(result_type) >= masklen) {
                 return t;
             } else {
@@ -235,11 +235,12 @@ void in_memory_generate(uint32_t thread)
         // every thread considers each monomial in the range
         // but it will only work with monomials that match
         // the phi condition.
-        uint128_t mpx = get_mask_bits(px);
+        mask_int_t mpx = get_mask_bits(px);
         idx = phi(mpx);
         if (unlikely(idx == thread))
         {
 #ifdef DEBUG_MESSAGES
+            //Ensure exponentiation code is working as it should
             if (gf_exp2(exponent) != px)
                 cerr << "Exponentiation error" << exponent << " " << hexmask_representation(gf_exp2(exponent)).str() << " " << hexmask_representation(px).str() << endl;
             candidated++;
@@ -267,7 +268,7 @@ void in_memory_generate(uint32_t thread)
                 imask_t imaskxor = xor_imask(it->second.imask, imbits);
                 uint128_t py = unpack_imask(imaskxor);
 #else
-                uint128_t py = get_imask_bits(px^gf_exp2(unpack_exp(exponent2)));
+                imask_int_t py = get_imask_bits(px^gf_exp2(unpack_exp(exponent2)));
 #endif
 #ifdef DEBUG_MESSAGES
                 added++;
@@ -494,6 +495,7 @@ int main()
     cout << "Mask:        " << hexmask_representation(mask).str() << endl;
     cout << "Mask bits:   " << masklen << endl;
     cout << "l2(mred):    " << log_mdrop << endl;
+    cout << "Exp bsize:   " << exp_bit_len << endl;
     cout << "Exp size:    " << sizeof(exp_t) << endl;
     cout << "Cmap_p size: " << sizeof(cmap_poly) << endl;
     cout << "Cmap size:   " << sizeof(pair<mask_t, cmap_poly>) << endl;

--- a/polyfinder/square.cpp
+++ b/polyfinder/square.cpp
@@ -111,7 +111,7 @@ namespace std {
         typedef size_t result_type;
         PUREFUN inline result_type operator () (const argument_type& x) const
         {
-            imask_int_t t = get_imask_bits(gf_exp2(unpack_exp(x.e1))^gf_exp2(unpack_exp(x.e2)));
+            imask_int_t t = get_imask_bits(gf_exp2_xor_2(unpack_exp(x.e1),unpack_exp(x.e2)));
             if constexpr (sizeof(result_type) >= imasklen) {
                 return t;
             } else {
@@ -151,12 +151,12 @@ PUREFUN constexpr inline bool operator==(const imask_t& lhs, const imask_t& rhs)
 
 PUREFUN inline bool operator==(const clay_poly& x, const clay_poly& y)
 {
-    return (gf_exp2(unpack_exp(x.e1))^gf_exp2(unpack_exp(x.e2))) == (gf_exp2(unpack_exp(y.e1))^gf_exp2(unpack_exp(y.e2)));
+    return (gf_exp2_xor_2(unpack_exp(x.e1),unpack_exp(x.e2))) == (gf_exp2_xor_2(unpack_exp(y.e1),unpack_exp(y.e2)));
 }
 
 PUREFUN inline bool operator==(const cmap_poly& x, const cmap_poly& y)
 {
-    return (gf_exp2(unpack_exp(x.exponent))& mask)==((gf_exp2(unpack_exp(y.exponent)))& mask);
+    return (gf_exp2_xor_2(unpack_exp(x.exponent),unpack_exp(y.exponent))& mask) == 0;
 }
 
 #define map_t phmap::flat_hash_map
@@ -252,7 +252,7 @@ static inline void in_memory_merge(int threadid, uint64_t bucket)
     for(int i = 1; i < THREADS; ++i) {
         for (auto& it: collision_layer[i][bucket])
         {
-            imask_t imask = pack_imask(get_imask_bits(gf_exp2(unpack_exp(it.e1))^gf_exp2(unpack_exp(it.e2))));
+            imask_t imask = pack_imask(get_imask_bits(gf_exp2_xor_2(unpack_exp(it.e1),unpack_exp(it.e2))));
             auto [it2, result] = base.try_emplace(
                 imask, clay_poly {it}
             );

--- a/polyfinder/square.cpp
+++ b/polyfinder/square.cpp
@@ -1,15 +1,15 @@
+#include "config.h"
 #include <iostream>
 #include <atomic>
 #include <thread>
 #include <new>
 #include <fstream>
+#include <cassert>
 
 #include <execution>
 #include <algorithm>
 
 #include "parallel_hashmap/phmap.h"
-
-#include "config.h"
 
 #include "gf2_monomial.cpp"
 #include "stringops.cpp"
@@ -197,10 +197,9 @@ static inline void in_memory_generate(int threadid, uint64_t task)
         if (unlikely(idx == task))
         {
             mpx /= STAGE1_TASKS; //Reduce mpx to the real number of elements
-#ifdef DEBUG_MESSAGES
             //Ensure exponentiation code is working as it should
-            if (gf_exp2(exponent) != px)
-                cerr << "Exponentiation error" << exponent << " " << hexmask_representation(gf_exp2(exponent)).str() << " " << hexmask_representation(px).str() << endl;
+            assert(gf_exp2(exponent) == px);
+#ifdef DEBUG_MESSAGES
             candidated++;
 #endif
 #if !CMAP_DROP_IMASK

--- a/polyfinder/utils.cpp
+++ b/polyfinder/utils.cpp
@@ -1,3 +1,4 @@
+#define UNUSED(x) (void)(x)
 #ifdef __GNUC__
 #define PUREFUN [[gnu::pure]]
 #define likely(x)       __builtin_expect((x),1)

--- a/polyfinder/utils.cpp
+++ b/polyfinder/utils.cpp
@@ -25,13 +25,17 @@ PUREFUN constexpr inline uint32_t get_degree(uint128_t px)
         return 63-__builtin_clzll(lo|1);
 }
 
-PUREFUN inline uint32_t popcnt128(uint128_t px)
+PUREFUN constexpr inline int popcnt128(uint128_t px)
 {
     unsigned long long hi = px >> 64, lo = px;
     return __builtin_popcountll(hi) + __builtin_popcountll(lo);
 }
+PUREFUN constexpr inline int popcnt64(uint64_t px)
+{
+    return __builtin_popcountll((unsigned long long)px);
+}
 #else
-PUREFUN inline uint32_t get_degree(uint128_t px)
+PUREFUN constexpr inline uint32_t get_degree(uint128_t px)
 {
     uint32_t degree = 0;
 
@@ -47,9 +51,9 @@ PUREFUN inline uint32_t get_degree(uint128_t px)
     return degree;
 }
 
-PUREFUN inline uint32_t popcnt128(uint128_t px)
+PUREFUN constexpr inline int popcnt128(uint128_t px)
 {
-    uint32_t rv = 0;
+    int rv = 0;
 
     for (uint32_t i = 0; i < 128; ++i)
     {
@@ -58,7 +62,31 @@ PUREFUN inline uint32_t popcnt128(uint128_t px)
     }
     return rv;
 }
+
+PUREFUN constexpr inline int popcnt64(uint64_t px)
+{
+    int rv = 0;
+
+    for (uint32_t i = 0; i < 64; ++i)
+    {
+        rv += (px & 0x1);
+        px >>= 1;
+    }
+    return rv;
+}
 #endif
+
+//For now this is a very trivial optimization, if the map_size is going to
+//be a power of two drop one element. This is because we use element 0
+//to indicate that the element is not present on the allocated memory
+PUREFUN constexpr inline uint64_t optimize_map_size (uint64_t map_size)
+{
+    if (map_size > (1<<20) && popcnt64(map_size) == 1)
+        return map_size-1;
+    else
+        return map_size;
+}
+
 
 PUREFUN constexpr inline uint32_t get_degree(uint256_t px)
 {


### PR DESCRIPTION
Use PEXT to handle masks
Use a fixed array on stage 1 instead of a hash table (since they would be dense anyways)
Use a thread pool approach on generate, threads still append data based on their thread id, but you can have more generation tasks than threads to reduce the size of the stage 1 hash table in exchange for longer run times.
Use a thread pool approach on merge, each bucket is considered a different task, threads will pick the first unprocessed bucket, process it, and repeat until all buckets are done. Buckets cost around (THREADS*4k) each but can be very helpful in making processing faster and the more expensive second stage hash tables smaller.